### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ rvm:
 before_script:
   - gem install awesome_bot
 script:
-  - awesome_bot README.md
+  - awesome_bot README.md --white-list psequel

--- a/README.md
+++ b/README.md
@@ -85,15 +85,15 @@ A curated list of awesome PostgreSQL software, libraries, tools and resources, i
 * [tutorialspoint PostgreSQL tutorial](http://www.tutorialspoint.com/postgresql/) - A very extensive collection of tutorials on PostgreSQL
 * [Postgres Guide](http://postgresguide.com/) - A guide designed as an aid for beginners and experienced users to find specific tips and explore tools available within Postgres
 * [Backup and recover a Postgres DB using wal-e](https://coderwall.com/p/cwe2_a/backup-and-recover-a-postgres-db-using-wal-e) - A tutorial about setting up continuous archiving in PostgreSQL using wal-e
-* [PostgreSQL Exercises](http://pgexercises.com/) - A site  to make it easy to learn PostgreSQL by doing
+* [PostgreSQL Exercises](https://pgexercises.com/) - A site  to make it easy to learn PostgreSQL by doing
 
 ### Blogs
-* [Planet PostgreSQL](https://planet.postgresql.org/) - A blog aggregation service for PostgreSQL
+* [Planet PostgreSQL](http://planet.postgresql.org/) - A blog aggregation service for PostgreSQL
 * [Craig Kerstiens Postgres Posts](http://www.craigkerstiens.com/categories/postgres/) - A set of posts on Postgres cool features/tips/tricks
 
 ### Newsletters
 
-* [Postgres Weekly](http://www.postgresweekly.com) - A weekly newsletter that contains articles, news, and repos relevant to Postgres
+* [Postgres Weekly](http://postgresweekly.com/) - A weekly newsletter that contains articles, news, and repos relevant to Postgres
 
 ### PaaS
 *(Postgres as a Service)*


### PR DESCRIPTION
This pull addresses Travis issues
- white list `psequel` (the link is up but having issue in [Travis](https://travis-ci.org/dhamaniasad/awesome-postgres/builds/109838713))
- redirects below

### HTTPS Corrected URLs 
Was | Now 
--- | --- 
http://pgexercises.com/ | https://pgexercises.com/ 


### Other Corrected URLs 
Was | Now 
--- | --- 
http://www.postgresweekly.com | http://postgresweekly.com/ 
https://planet.postgresql.org/ | http://planet.postgresql.org/ 
