### PR TITLE
Add Database Labs -- Postgres as a Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,4 +99,5 @@ A curated list of awesome PostgreSQL software, libraries, tools and resources, i
 
 ### PaaS
 *(Postgres as a Service)*
+* [Database Labs](https://www.databaselabs.io) - Get a production-ready cloud Postgres server in minutes, from $20 a month. Backups, monitoring, patches, and 24/7 tech support all included.
 * [ElephantSQL](http://www.elephantsql.com) - Offers databases ranging from shared servers for smaller projects and proof of concepts, up to enterprise grade multi server setups. Has free plan for up to 5 DBs, 20 MB each.


### PR DESCRIPTION
 [Database Labs](https://www.databaselabs.io) - Get a production-ready cloud Postgres server in minutes, from $20 a month. Backups, monitoring, patches, and 24/7 tech support all included.