### PR TITLE
Add Stolon to High-Availability section

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A curated list of awesome PostgreSQL software, libraries, tools and resources, i
 
 ### High-Availability
 * [Patroni](https://github.com/zalando/patroni) - A template for PostgreSQL HA with ZooKeeper or etcd
+* [Stolon](https://github.com/sorintlab/stolon) - PostgreSQL HA based on Consul or etcd, with Kubernetes integration
 * [pglookout](https://github.com/ohmu/pglookout) - Replication monitoring and failover daemon
 * [repmgr](https://github.com/2ndQuadrant/repmgr) - Is an open-source tool suite to manage replication and failover in a cluster of PostgreSQL servers
 * [Slony-I](http://slony.info) - A "master to multiple slaves" replication system with cascading and failover


### PR DESCRIPTION
I've checked it recently (see https://github.com/sorintlab/stolon/issues/168 ) - it works, handles shutting machines down and netsplits as expected, and it's quite easy to use.