### PR TITLE
Add Citus extension and Citus Cloud Paas, remove deprecated pg_shard

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ A curated list of awesome PostgreSQL software, libraries, tools and resources, i
 * [PgHero](https://github.com/ankane/pghero) - PostgreSQL insights made easy.
 * [pgtune](https://github.com/gregs1104/pgtune/) - PostgreSQL configuration wizard.
 * [pgtune](http://pgtune.leopard.in.ua/) - Online version of PostgreSQL configuration wizard.
-* [pgconfig.org](http://pgconfig.org/) - PostgreSQL Online Configuration Tool (also based on pgtune).
+* [pgconfig.org](https://www.pgconfig.org/) - PostgreSQL Online Configuration Tool (also based on pgtune).
 * [PoWA](http://dalibo.github.io/powa/) - PostgreSQL Workload Analyzer gathers performance stats and provides real-time charts and graphs to help monitor and tune your PostgreSQL servers.
 
 ### Utilities

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ A curated list of awesome PostgreSQL software, libraries, tools and resources, i
 
 ### PaaS *(PostgreSQL as a Service)*
 * [Aiven PostgreSQL](https://aiven.io/postgresql) - PostgreSQL as a service in AWS, Azure, DigitalOcean, Google Cloud and UpCloud; plans range from $19/month single node instances to large highly-available setups, free trial for two weeks.
+* [Citus Cloud](https://www.citusdata.com/product/cloud) - Production grade scaled out PostgreSQL as a service enabling real-time workloads and sharding your multi-tenant apps.
 * [Database Labs](https://www.databaselabs.io) - Get a production-ready cloud PostgreSQL server in minutes, from $20 a month Backups, monitoring, patches, and 24/7 tech support all included.
 * [ElephantSQL](https://www.elephantsql.com/) - Offers databases ranging from shared servers for smaller projects and proof of concepts, up to enterprise grade multi server setups. Has free plan for up to 5 DBs, 20 MB each.
 * [Heroku Postgres](https://elements.heroku.com/addons/heroku-postgresql) - Plans from free to huge, operated by PostgreSQL experts. Does not require running your app on Heroku. Free plan includes 10,000 rows, 20 connections, up to two backups, and has PostGIS support.


### PR DESCRIPTION
This change adds Citus Cloud, which offers a scaled-out and fully managed PostgreSQL cluster, to Paas list. 