### PR TITLE
README: High-Availability: Add link to PAF

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ A curated list of awesome PostgreSQL software, libraries, tools and resources, i
 * [pglookout](https://github.com/ohmu/pglookout) - Replication monitoring and failover daemon.
 * [repmgr](https://github.com/2ndQuadrant/repmgr) - Open-source tool suite to manage replication and failover in a cluster of PostgreSQL servers.
 * [Slony-I](http://slony.info) - "Master to multiple slaves" replication system with cascading and failover.
+* [PAF](https://github.com/dalibo/PAF) - PostgreSQL Automatic Failover: High-Availibility for Postgres, based on Pacemaker and Corosync.
 
 ### Backups
 * [Barman](http://www.pgbarman.org/) - Backup and Recovery Manager for PostgreSQL by 2ndQuadrant.


### PR DESCRIPTION
Add link to [PAF](https://github.com/dalibo/PAF): PostgreSQL Automatic Failover: High-Availibility for Postgres, based on Pacemaker and Corosync. Closes #150.