### PR TITLE
add pREST ( Serve a RESTful API from any PostgreSQL database )

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ A curated list of awesome PostgreSQL software, libraries, tools and resources, i
 * [PGXN client](https://github.com/dvarrazzo/pgxnclient) - Command line tool to interact with the PostgreSQL Extension Network
 * [postgresql-metrics](https://github.com/spotify/postgresql-metrics) - Tool that extracts and provides metrics for your PostgreSQL database.
 * [PostgREST](https://github.com/begriffs/postgrest) - Serves a fully RESTful API from any existing PostgreSQL database.
+* ]pREST](https://github.com/nuveo/prest) - Serve a RESTful API from any PostgreSQL database (Golang)
 * [yoke](https://github.com/nanopack/yoke) - PostgreSQL high-availability cluster with auto-failover and automated cluster recovery.
 * [pglistend](https://github.com/kabirbaidhya/pglistend) - A lightweight PostgresSQL `LISTEN`/`NOTIFY` daemon built on top of `node-postgres`.
 * [ZSON](https://github.com/postgrespro/zson) - PostgreSQL extension for transparent JSONB compression

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ A curated list of awesome PostgreSQL software, libraries, tools and resources, i
 * [PGXN client](https://github.com/dvarrazzo/pgxnclient) - Command line tool to interact with the PostgreSQL Extension Network
 * [postgresql-metrics](https://github.com/spotify/postgresql-metrics) - Tool that extracts and provides metrics for your PostgreSQL database.
 * [PostgREST](https://github.com/begriffs/postgrest) - Serves a fully RESTful API from any existing PostgreSQL database.
-* ]pREST](https://github.com/nuveo/prest) - Serve a RESTful API from any PostgreSQL database (Golang)
+* [pREST](https://github.com/nuveo/prest) - Serve a RESTful API from any PostgreSQL database (Golang)
 * [yoke](https://github.com/nanopack/yoke) - PostgreSQL high-availability cluster with auto-failover and automated cluster recovery.
 * [pglistend](https://github.com/kabirbaidhya/pglistend) - A lightweight PostgresSQL `LISTEN`/`NOTIFY` daemon built on top of `node-postgres`.
 * [ZSON](https://github.com/postgrespro/zson) - PostgreSQL extension for transparent JSONB compression


### PR DESCRIPTION
I would like to add pREST Tool .
  * [pREST](https://github.com/nuveo/prest) - Serve a RESTful API from any PostgreSQL database (Golang) 


imho : sometimes it is also important the implementation language - so I added this information :  `(Golang)` 
