### PR TITLE
Add GeoNames PostgreSQL DataImport Script

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ For Database Management
 * [sqitch](https://github.com/theory/sqitch) - Tool for managing versioned schema deployment
 * [pgmigrate](https://github.com/yandex/pgmigrate) - CLI tool to evolve schema migrations, developed by Yandex.
 * [pgcmp](https://github.com/cbbrowne/pgcmp) - Tool to compare database schemas, with capability to accept some persistent differences
+* [GeoNames-PostgreSQL-DataImport](https://github.com/AGPDev/GeoNames-PostgreSQL-DataImport) - Shell Script for importing geonames.org data dumps into a PostgreSQL database.
+
 
 ### Language bindings
 * Common Lisp: [Postmodern](https://github.com/marijnh/Postmodern)


### PR DESCRIPTION
Shell Script for importing geonames.org data dumps into a PostgreSQL database.