### PR TITLE
Add pg_insights

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ For Database Management
 * [pgclimb](https://github.com/lukasmartinelli/pgclimb) - Export data from PostgreSQL into different data formats.
 * [pgfutter](https://github.com/lukasmartinelli/pgfutter) - Import CSV and JSON into PostgreSQL the easy way.
 * [PGInsight](http://pginsight.io/) - CLI tool to easily dig deep inside your PostgreSQL database.
+* [pg_insights](https://github.com/lob/pg_insights) - Convenient SQL for monitoring Postgres database health.
 * [pgloader](https://github.com/dimitri/pgloader) - Loads data into PostgreSQL using the COPY streaming protocol, and does so with separate threads for reading and writing data.
 * [pgMustard](https://www.pgmustard.com/) - A modern user interface
 for `EXPLAIN ANALYSE`, that also provides performance tips (Commercial Software).


### PR DESCRIPTION
[pg_insights](https://github.com/lob/pg_insights) is a collection of SQL commands for monitoring Postgres health. It has been battle-tested in production environments at [Lob](https://lob.com), helping us pinpoint Postgres issues. It is inspired by the excellent [pg_extras](https://github.com/heroku/heroku-pg-extras) tool.