### PR TITLE
Added asyncpg to python

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ for `EXPLAIN`, that also provides performance tips (Commercial Software).
 * Node: [node-postgres](https://github.com/brianc/node-postgres), [pg-promise](https://github.com/vitaly-t/pg-promise), [pogi](https://github.com/holdfenytolvaj/pogi), [slonik](https://github.com/gajus/slonik)
 * Perl: [DBD-Pg](https://metacpan.org/pod/distribution/DBD-Pg/Pg.pm)
 * PHP: [Pomm](http://www.pomm-project.org), [pecl/pq](https://github.com/m6w6/ext-pq)
-* Python: [psycopg2](https://pypi.org/project/psycopg2/)
+* Python: [psycopg2](https://pypi.org/project/psycopg2/), [asyncpg](https://pypi.org/project/asyncpg/)
 * Ruby: [pg](https://bitbucket.org/ged/ruby-pg/wiki/Home)
 * Rust: [rust-postgresql](https://github.com/sfackler/rust-postgres)
 * Lua: [luapgsql](https://github.com/arcapos/luapgsql)


### PR DESCRIPTION
There multiple PostgreSQL drivers, but most of them are based on the interface provided by psycopg2. asyncpg besides being asyncio compatible driver it also did not followed to be compatible with Python's DB-API and instead provided interface that directly matches PostgreSQL API. The disadvantage to it is that it probably won't work with other ORM libraries, but in exchange for it it is extremely fast and much better alternative if you want to utilize PostgreSQL latest features in your code.