### PR TITLE
Add category Security, and Acra into it

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ For Database Management
 * [AgensGraph](https://bitnine.net/) - Powerful graph database based on the PostgreSQL.
 * [Greenplum Database](https://github.com/greenplum-db/gpdb) - Open source fork of PostgreSQL for large data volumes.
 
+### Security
+* [Acra](https://github.com/cossacklabs/acra) - SQL database security suit: proxy for data protection with transparent "on the fly" data encryption, SQL firewall (SQL injections prevention), intrusion detection system.
+
 ### Monitoring
 * [check\_pgactivity](https://github.com/OPMDG/check_pgactivity) - check\_pgactivity is designed to monitor PostgreSQL clusters from Nagios. It offers many options to measure and monitor useful performance metrics.
 * [Check\_postgres](https://github.com/bucardo/check_postgres) - Nagios check\_postgres plugin for checking status of PostgreSQL databases.

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ For Database Management
 * [Greenplum Database](https://github.com/greenplum-db/gpdb) - Open source fork of PostgreSQL for large data volumes.
 
 ### Security
-* [Acra](https://github.com/cossacklabs/acra) - SQL database security suit: proxy for data protection with transparent "on the fly" data encryption, SQL firewall (SQL injections prevention), intrusion detection system.
+* [Acra](https://github.com/cossacklabs/acra) - SQL database security suite: proxy for data protection with transparent "on the fly" data encryption, SQL firewall (SQL injections prevention), intrusion detection system.
 
 ### Monitoring
 * [check\_pgactivity](https://github.com/OPMDG/check_pgactivity) - check\_pgactivity is designed to monitor PostgreSQL clusters from Nagios. It offers many options to measure and monitor useful performance metrics.


### PR DESCRIPTION
Added Security category, add Acra.

[Acra](https://github.com/cossacklabs/acra) is a database security proxy that helps developer to encrypt data before storing in the database ("transparent field level encryption").