### PR TITLE
add sqlline to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ For Database Management
 * [psql](https://www.postgresql.org/docs/current/static/app-psql.html) - The built-in PostgreSQL CLI client
 * [psql2csv](https://github.com/fphilipe/psql2csv) - Run a query in psql and output the result as CSV
 * [nancy](https://gitlab.com/postgres-ai/nancy) - The Nancy CLI is a unified way to manage automated database experiments either in clouds or on-premise
+* [sqlline](https://github.com/julianhyde/sqlline) - JDBC CLI with autocompletion, syntax highlighting, supporting pgSQL 
 * [schemaspy](https://github.com/schemaspy/schemaspy) - SchemaSpy is a JAVA JDBC-compliant tool for generating your database to HTML documentation, including Entity Relationship diagrams
 
 ### Server


### PR DESCRIPTION
add sqlline - cli with autocompletion, syntax highlighting, supporting pgSQL 
more feature description are available at sqlline demos page https://github.com/julianhyde/sqlline/wiki/Demos