### PR TITLE
Add db_converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,8 @@ for `EXPLAIN`, that also provides performance tips (Commercial Software).
 * [pg-differ](https://github.com/multum/pg-differ) - Tool for easy initialization / updating of the structure of PostgreSQL tables, migration alternative (Node.js).
 * [sqlcheck](https://github.com/jarulraj/sqlcheck) - Automatically detects common SQL anti-patterns. Such anti-patterns often slow down queries. Addressing them will, therefore, help accelerate queries.
 * [postgres-checkup](https://gitlab.com/postgres-ai/postgres-checkup) - a new-generation diagnostics tool that allows users to collect deep analysis of the health of a Postgres database.
-* [ScaffoldHub.io](https://scaffoldhub.io) - Generate fullstack PostgreSQL apps with Angular, Vue or React (Commercial Software). 
+* [ScaffoldHub.io](https://scaffoldhub.io) - Generate fullstack PostgreSQL apps with Angular, Vue or React (Commercial Software).
+* [db_converter](https://github.com/masterlee998/db_converter) - open-source database migration tool for PostgreSQL 9.6+ designed for high loaded installations.
 
 ### Language bindings
 * Common Lisp: [Postmodern](https://github.com/marijnh/Postmodern)


### PR DESCRIPTION
`db_converter` is an open-source database migration tool for PostgreSQL 9.6+ designed for high loaded installations.

Tasks that can be solved using `db_converter`:

* Transactional [modification of data](https://github.com/masterlee998/db_converter/wiki/Use-cases#update-all-records-in-huge-table) of any volume
* Database [structure changing](https://github.com/masterlee998/db_converter/tree/master/packets/test_int4_to_int8) with locks control
* System and application [notifications](https://github.com/masterlee998/db_converter/wiki/Use-cases#alerts-examples) via `mattermost` (or any other messenger)
* Database maintenance ([deleting](https://github.com/masterlee998/db_converter/wiki/Use-cases#delete-old-data-from-huge-table) old data, creating new [schemas](https://github.com/masterlee998/db_converter/blob/master/packets/dba_clone_schema/01_step.sql), etc.)
* [Export](https://github.com/masterlee998/db_converter/tree/master/packets/test_export_data) data in `csv` format into encrypted archive

The key features are:

* Only plain SQL scripts with placeholders
* Parallel processing of several databases
* Handling of the locks to avoid impact on the regular workload

[Use cases](https://github.com/masterlee998/db_converter/wiki/Use-cases)