### PR TITLE
Extensions: Added pg_stat_monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
     - [Language bindings](#language-bindings)
     - [PaaS (PostgreSQL as a Service)](#paas-postgresql-as-a-service)
     - [Docker images](#docker-images)
-  - [Resources](#resources)
+- [Resources](#resources)
     - [Tutorials](#tutorials)
     - [Blogs](#blogs)
     - [Articles](#articles)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
     - [Language bindings](#language-bindings)
     - [PaaS (PostgreSQL as a Service)](#paas-postgresql-as-a-service)
     - [Docker images](#docker-images)
-- [Resources](#resources)
+  - [Resources](#resources)
     - [Tutorials](#tutorials)
     - [Blogs](#blogs)
     - [Articles](#articles)
@@ -126,6 +126,7 @@ For Database Management
 * [pg\_partman](https://github.com/pgpartman/pg_partman) - Partition management extension for PostgreSQL.
 * [pg\_paxos](https://github.com/citusdata/pg_paxos/) - Basic implementation of Paxos and Paxos-based table replication for a cluster of PostgreSQL nodes.
 * [pg\_shard](https://github.com/citusdata/pg_shard) - Extension to scale out real-time reads and writes.
+* [pg\_stat\_monitor](https://github.com/percona/pg_stat_monitor) - Query Performance Monitoring tool for PostgreSQL.
 * [PGStrom](https://wiki.postgresql.org/wiki/PGStrom) - Extension to offload CPU intensive workloads to GPU.
 * [pgxn](https://pgxn.org/) PostgreSQL Extension Network - central distribution point for many open-source PostgreSQL extensions
 * [PipelineDB](https://www.confluent.io/blog/pipelinedb-team-joins-confluent/) - A PostgreSQL extension that runs SQL queries continuously on streams, incrementally storing results in tables.


### PR DESCRIPTION
[pg_stat_monitor](https://github.com/percona/pg_stat_monitor) provides improved insights that allow database users to understand query origins, execution, planning statistics and details, query information, and metadata.

This significantly improves observability, enabling users to debug and tune query performance. pg_stat_monitor is developed on the basis of pg_stat_statements as its more advanced replacement.

Signed-off-by: Lenz Grimmer <lenz.grimmer@percona.com>