### PR TITLE
Adding ScaleGrid DBaaS

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ for `EXPLAIN`, that also provides performance tips (Commercial Software).
 * [ElephantSQL](https://www.elephantsql.com/) - Offers databases ranging from shared servers for smaller projects and proof of concepts, up to enterprise grade multi server setups. Has free plan for up to 5 DBs, 20 MB each.
 * [Google Cloud SQL for PostgreSQL](https://cloud.google.com/sql/docs/postgres/) - Fully-managed database service that makes it easy to set up, maintain, manage, and administer your PostgreSQL relational databases on Google Cloud Platform.
 * [Heroku Postgres](https://elements.heroku.com/addons/heroku-postgresql) - Plans from free to huge, operated by PostgreSQL experts. Does not require running your app on Heroku. Free plan includes 10,000 rows, 20 connections, up to two backups, and has PostGIS support.
+* [ScaleGrid PostgreSQL DBaaS](https://scalegrid.io/postgresql.html) - Fully managed PostgreSQL hosting with high availability, dedicated servers, and superuser control on the #1 multi-cloud Amazon RDS alternative.
 * [Scaleway Managed Database](https://www.scaleway.com/en/database/) - Fully managed PostgreSQL databases with HA, scaling, and automated backups, hosted in the EU. Starting at €10 per month.
 
 ### Docker images


### PR DESCRIPTION
Very interesting service provider IMHO, this is one of the main reason I looked into it:

```
ScaleGrid is the only DBaaS that lets you host in your own cloud account and
save with AWS or Azure Reserved Instances or GCP Committed Use Discount.
```