### PR TITLE
Add FerretDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ For Database Management
 * [Postgres-XL](https://www.postgres-xl.org/) - Scalable Open Source PostgreSQL-based Database Cluster.
 * [AgensGraph](https://bitnine.net/) - Powerful graph database based on the PostgreSQL.
 * [Greenplum Database](https://github.com/greenplum-db/gpdb) - Open source fork of PostgreSQL for large data volumes.
+* [FerretDB](https://www.ferretdb.io) - A truly Open Source MongoDB alternative on top of PostgreSQL.
 
 ### Monitoring
 * [check\_pgactivity](https://github.com/OPMDG/check_pgactivity) - check\_pgactivity is designed to monitor PostgreSQL clusters from Nagios. It offers many options to measure and monitor useful performance metrics.


### PR DESCRIPTION
This PR adds FerretDB – a truly Open Source MongoDB alternative on top of PostgreSQL.

(full disclosure: I'm a FerretDB author, but that's not the only reason I think it is awesome)