### PR TITLE
Added link of PostgreSQL Roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,4 +283,4 @@ for `EXPLAIN`, that also provides performance tips (Commercial Software).
 * [#postgresql on Freenode](https://webchat.freenode.net/#postgresql) - The most popular IRC channel about Postgres on Freenode with over 1000 users
 
 ### Roadmaps
-* [PostgreSQL Roadmap](https://roadmap.sh/postgresql-dba) - Step wise guide to PostgreSQL
+* [PostgreSQL Roadmap](https://roadmap.sh/postgresql-dba) - A roadmap providing step wise guide to PostgreSQL.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
     - [Newsletters](#newsletters)
     - [Videos](#videos)
     - [Community](#community)
+    - [Roadmaps](#roadmaps)
 
 ### High-Availability
 * [BDR](https://github.com/2ndQuadrant/bdr) - BiDirectional Replication - a multimaster replication system for PostgreSQL
@@ -280,3 +281,6 @@ for `EXPLAIN`, that also provides performance tips (Commercial Software).
 * [Slack](https://postgres-slack.herokuapp.com/) - Slack channel for Postgres with over 7000 users
 * Telegram - Several groups for PostgreSQL in different langauges: [Russian](https://t.me/pgsql) >4200 people, [Brazilian Portuguese](https://t.me/postgresqlbr) >2300 people, [Indonesian](https://t.me/postgresql_id) ~1000 people, [English](https://t.me/postgreschat) >750 people
 * [#postgresql on Freenode](https://webchat.freenode.net/#postgresql) - The most popular IRC channel about Postgres on Freenode with over 1000 users
+
+### Roadmaps
+* [PostgreSQL Roadmap](https://roadmap.sh/postgresql-dba) - Step wise guide to PostgreSQL


### PR DESCRIPTION
Hi Asad,

I came across your repository [awesome-postgres](https://github.com/dhamaniasad/awesome-postgres) and found it to be a valuable resource for PostgreSQL enthusiasts.

While browsing through the repository, I noticed that it was missing links to any structured guides such as the famous ["PostgreSQL Roadmap"](https://roadmap.sh/postgresql-dba). I took the initiative to submit a ["Pull Request"](https://github.com/dhamaniasad/awesome-postgres/pull/343) adding it in a under resources section.

Thank you for your time and effort in maintaining this valuable resource :)

Best,
Mouaaz