### PR TITLE
Add pgvector blog.

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ for `EXPLAIN`, that also provides performance tips (Commercial Software).
 * [pg-utils](https://github.com/dataegret/pg-utils) - Useful DBA tools by Data Egret
 
 ### Blogs
+* [Enabling Vector Search in Aiven for PostgreSQL® with pgvector](https://aiven.io/blog/aiven-for-postgres-supports-pgvector) - Aiven blog.
 * [Planet PostgreSQL](https://planet.postgresql.org/) - Blog aggregation service for PostgreSQL.
 * [Andrew Dunstan's PostgreSQL and Technical blog](http://adpgtech.blogspot.com/search/label/PostgreSQL/)
 * [Bruce Momjian's PostgreSQL blog](https://momjian.us/main/blogs/pgblog.html)


### PR DESCRIPTION
This PR adds [this blog on pgvector](https://aiven.io/blog/aiven-for-postgres-supports-pgvector) to the list.