### PR TITLE
Add pg-schema-diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ For Database Management
 ### CLI
 * [atlas](https://github.com/ariga/atlas) - Atlas is a tool for managing and migrating database schemas using modern DevOps principles.
 * [pgcli](https://github.com/dbcli/pgcli) - Postgres CLI with autocompletion and syntax highlighting
+* [pg-schema-diff](https://github.com/stripe/pg-schema-diff) - CLI (and Golang library) for diffing Postgres schemas and generating SQL migrations with minimal locking.
 * [pgsh](https://github.com/sastraxi/pgsh) - Branch your PostgreSQL Database like Git
 * [psql](https://www.postgresql.org/docs/current/static/app-psql.html) - The built-in PostgreSQL CLI client
 * [psql2csv](https://github.com/fphilipe/psql2csv) - Run a query in psql and output the result as CSV


### PR DESCRIPTION
Add [pg-schema-diff](https://github.com/stripe/pg-schema-diff)

Notable because it:
- Generates diff 
- Attempts to minimize locking with vanilla SQL (e.g., online not nulls)
- Migration hazards system (warns about dangerous migrations)
- Production-level Golang library