### PR TITLE
Add BeanQueue

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
     - [Server](#server)
     - [Monitoring](#monitoring)
     - [Extensions](#extensions)
+    - [Work Queues](#work-queues)
     - [Optimization](#optimization)
     - [Utilities](#utilities)
     - [Language bindings](#language-bindings)
@@ -168,7 +169,7 @@
 * [ParadeDB](https://github.com/paradedb/paradedb) -  Postgres for Search and Analytics
 
 ### Work Queues
-* [BeanQueue](https://github.com/LaunchPlatform/bq) - A lightweight Python work queue framework based on [SQLAlchemy](https://www.sqlalchemy.org/), PostgreSQL [SKIP LOCKED queries](https://www.2ndquadrant.com/en/blog/what-is-select-skip-locked-for-in-postgresql-9-5/) and [NOTIFY](https://www.postgresql.org/docs/current/sql-notify.html) / [LISTEN](https://www.postgresql.org/docs/current/sql-listen.html) statements
+* [BeanQueue](https://github.com/LaunchPlatform/bq) - A Python work queue framework based on SKIP LOCKED, LISTEN and NOTIFY
 
 ### Optimization
 * [EverSQL](https://www.eversql.com/) - Automated query optimization tool, monitoring and analysis tool, indexing recommendation tool. (Commercial Software)

--- a/README.md
+++ b/README.md
@@ -167,6 +167,9 @@
 * [PostgresML](https://postgresml.org/) - Machine learning and AI inside your database, including vectors, LLMs, and classic ML. Train, predict and manage the entire lifecycle of machine learning models using only SQL.
 * [ParadeDB](https://github.com/paradedb/paradedb) -  Postgres for Search and Analytics
 
+### Work Queues
+* [BeanQueue](https://github.com/LaunchPlatform/bq) - A lightweight Python work queue framework based on [SQLAlchemy](https://www.sqlalchemy.org/), PostgreSQL [SKIP LOCKED queries](https://www.2ndquadrant.com/en/blog/what-is-select-skip-locked-for-in-postgresql-9-5/) and [NOTIFY](https://www.postgresql.org/docs/current/sql-notify.html) / [LISTEN](https://www.postgresql.org/docs/current/sql-listen.html) statements
+
 ### Optimization
 * [EverSQL](https://www.eversql.com/) - Automated query optimization tool, monitoring and analysis tool, indexing recommendation tool. (Commercial Software)
 * [pg_flame](https://github.com/mgartner/pg_flame) - A flamegraph generator for query plans.


### PR DESCRIPTION
BeanQueue is a lightweight Python task queue framework based on [SQLAlchemy](https://www.sqlalchemy.org/), PostgreSQL [SKIP LOCKED queries](https://www.2ndquadrant.com/en/blog/what-is-select-skip-locked-for-in-postgresql-9-5/) and [NOTIFY](https://www.postgresql.org/docs/current/sql-notify.html) / [LISTEN](https://www.postgresql.org/docs/current/sql-listen.html) statements. It makes queue background task with database transaction easier than ever. The tasks can be created like any other ORM objects, added to session and committed altogether with other table rows.

We built this project internally for our own use, and we use it in production already. We think it could be helpful for others, so we open sourced it.

There are actually many PostgreSQL based worker queue system out there. BeanQueue is just one of them. That's why I added a new `Work Queues` section. To learn more about the alternatives, please see my [alternatives](https://github.com/LaunchPlatform/bq?tab=readme-ov-file#alternatives) section in the readme. I am not sure if I understand those projects enough to write a good short description for them, so I only open an PR for my own project.