### PR TITLE
Fix broken Slack invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ for `EXPLAIN`, that also provides performance tips (Commercial Software).
 ### Community
 * [Mailing lists](https://www.postgresql.org/list/) - Official mailing lists for Postgres for support, outreach, and more. One of the primary channels of communication in the Postgres community.
 * [Reddit](https://www.reddit.com/r/PostgreSQL/) - A reddit community for PostgreSQL users with over 12000 users
-* [Slack](https://postgres-slack.herokuapp.com/) - Slack channel for Postgres with over 7000 users
+* [Slack](https://pgtreats.info/slack-invite) - Slack workspace for Postgres with over 20k members
 * Telegram - Several groups for PostgreSQL in different languages: [Russian](https://t.me/pgsql) >4200 people, [Brazilian Portuguese](https://t.me/postgresqlbr) >2300 people, [Indonesian](https://t.me/postgresql_id) ~1000 people, [English](https://t.me/postgreschat) >750 people
 * [#postgresql on Freenode](https://webchat.freenode.net/#postgresql) - The most popular IRC channel about Postgres on Freenode with over 1000 users
 


### PR DESCRIPTION
Source https://www.postgresql.org/message-id/b3950236-359e-64de-1874-74f285f8a493%40ardentperf.com

Fix wording and update number while at it