### PR TITLE
Add `wtx`

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ for `EXPLAIN`, that also provides performance tips (Commercial Software).
 * Python: [psycopg2](https://pypi.org/project/psycopg2/), [asyncpg](https://pypi.org/project/asyncpg/)
 * R: [RPostgreSQL](https://github.com/tomoakin/RPostgreSQL)
 * Ruby: [pg](https://github.com/ged/ruby-pg)
-* Rust: [rust-postgresql](https://github.com/sfackler/rust-postgres), [pgx](https://github.com/tcdi/pgx)
+* Rust: [rust-postgresql](https://github.com/sfackler/rust-postgres), [pgx](https://github.com/tcdi/pgx), [wtx](https://github.com/c410-f3r/wtx)
 * Lua: [luapgsql](https://github.com/arcapos/luapgsql)
 
 ### PaaS *(PostgreSQL as a Service)*


### PR DESCRIPTION
`wtx` is written in Rust and provides "bindings" to PostgreSQL databases. It is one of the fastest, if not the fastest, implementation according to https://github.com/diesel-rs/metrics as well as internal benchmarks.

![image](https://github.com/user-attachments/assets/6be2b413-3920-40cb-94db-c17028718bd0)
