### PR TITLE
Add `{RPostgres}` link to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ for `EXPLAIN`, that also provides performance tips (Commercial Software).
 * Perl: [DBD-Pg](https://metacpan.org/pod/distribution/DBD-Pg/Pg.pm)
 * PHP: [Pomm](http://www.pomm-project.org), [pecl/pq](https://github.com/m6w6/ext-pq)
 * Python: [psycopg2](https://pypi.org/project/psycopg2/), [asyncpg](https://pypi.org/project/asyncpg/)
-* R: [RPostgreSQL](https://github.com/tomoakin/RPostgreSQL)
+* R: [RPostgres](https://github.com/r-dbi/RPostgres), [RPostgreSQL](https://github.com/tomoakin/RPostgreSQL)
 * Ruby: [pg](https://github.com/ged/ruby-pg)
 * Rust: [rust-postgresql](https://github.com/sfackler/rust-postgres), [pgx](https://github.com/tcdi/pgx)
 * Lua: [luapgsql](https://github.com/arcapos/luapgsql)


### PR DESCRIPTION
Adds a link to the [{RPostgres}](https://github.com/r-dbi/RPostgres) package, a DBI-compliant R library that serves as a modern alternative to [{RPostgreSQL}](https://github.com/tomoakin/RPostgreSQL).