### PR TITLE
Add ReleaseRun Vulnerability Scanner to Monitoring section

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@
 * [pg_exporter](https://github.com/Vonng/pg_exporter) - Fully customizable Prometheus exporter for PostgreSQL & Pgbouncer with fine-grained execution control.
 * [postgres_exporter](https://github.com/wrouesnel/postgres_exporter) - Prometheus exporter for PostgreSQL server metrics.
 * [StatsMgr](https://codeberg.org/data-bene/statsmgr) - An open-source PostgreSQL extension designed for efficient and organized advanced statistics management.
+* [ReleaseRun Vulnerability Scanner](https://releaserun.com/tools/vulnerability-scanner/) - Free tool that checks your PostgreSQL version against EOL dates, known CVEs, and support status. Covers all major versions from 10 through 18 with health grades and upgrade recommendations.
 
 ### Extensions
 * [pgxn](https://pgxn.org/) PostgreSQL Extension Network - central distribution point for many open-source PostgreSQL extensions.


### PR DESCRIPTION
Adds [ReleaseRun Vulnerability Scanner](https://releaserun.com/tools/vulnerability-scanner/) to the Monitoring section.

A free tool that checks PostgreSQL version health: EOL dates, known CVEs, support status, and upgrade recommendations. Covers all major versions from 10 through 18.

Useful alongside existing monitoring tools in the list. While most entries focus on runtime performance monitoring, this covers version lifecycle monitoring, which is a gap in the current list. Knowing your PostgreSQL version is approaching EOL or has unpatched CVEs is just as important as tracking query performance.

Also available as a CLI: `npx releaserun check` ([npm](https://www.npmjs.com/package/releaserun) | [GitHub](https://github.com/Releaserun/releaserun-cli)).