### PR TITLE
Add qail-zig under Zig language bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ for `EXPLAIN`, that also provides performance tips (Commercial Software).
 * Ruby: [pg](https://github.com/ged/ruby-pg)
 * Rust: [rust-postgresql](https://github.com/sfackler/rust-postgres), [pgx](https://github.com/tcdi/pgx), [wtx](https://github.com/c410-f3r/wtx)
 * TypeScript: [zapatos](https://github.com/jawj/zapatos)
-* Zig: [pg.zig](https://github.com/karlseguin/pg.zig)
+* Zig: [pg.zig](https://github.com/karlseguin/pg.zig), [qail-zig](https://github.com/qail-io/qail-zig)
 
 ### PaaS *(PostgreSQL as a Service)*
 * [Aiven PostgreSQL](https://aiven.io/postgresql) - PostgreSQL as a service in AWS, Azure, DigitalOcean, Google Cloud and UpCloud; plans range from $19/month single node instances to large highly-available setups, free trial for two weeks.


### PR DESCRIPTION
This PR adds one entry under Language bindings > Zig.

* [qail-zig](https://github.com/qail-io/qail-zig)

No other changes.
