### PR TITLE
Add Mindweave sample database to Tutorials section

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,7 @@ for `EXPLAIN`, that also provides performance tips (Commercial Software).
 * [PostgreSQL Primer for Busy People](https://zaiste.net/posts/postgresql-primer-for-busy-people/) - A collection of the most common commands used in PostgreSQL
 * [pg-utils](https://github.com/dataegret/pg-utils) - Useful DBA tools by Data Egret
 * [pagila](https://github.com/xzilla/pagila) - Pagila, Postgres Sample Database
+* [Mindweave Synthetic Business Data](https://github.com/MindweaveTech/sme-sim-sample) - 42-table synthetic SME dataset with double-entry accounting, 44 FK relationships, and tax compliance (AU/US/UK). Includes PostgreSQL-compatible SQL dump.
 * [SQL Syntax Cheat Sheet](https://github.com/mergisi/sql-syntax-cheat-sheet) - Comprehensive SQL syntax reference covering window functions, CTEs, and PostgreSQL-specific syntax (UPSERT, JSON queries, array operations).
 
 ### Blogs


### PR DESCRIPTION
Adds Mindweave Synthetic Business Data alongside existing sample databases (postgresDBSamples, pagila).

**42-table synthetic SME dataset** with PostgreSQL-compatible SQL dump:
- Double-entry accounting, 44 FK relationships
- Tax compliance for AU (GST/BAS), US (IRS/FICA), UK (HMRC/PAYE/VAT)
- Full schema.sql + INSERT statements included
- Also available in CSV, Parquet, SQLite

GitHub: https://github.com/MindweaveTech/sme-sim-sample