### PR TITLE
Add pgsql-hackers Weekly Digest to newsletters

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,7 @@ for `EXPLAIN`, that also provides performance tips (Commercial Software).
 
 * [Postgres Weekly](https://postgresweekly.com/) - Weekly newsletter that contains articles, news, and repos relevant to PostgreSQL.
 * [pgMustard newsletter](https://www.pgmustard.com/newsletter) - Monthly newsletter that contains Postgres performance articles and videos.
+* [pgsql-hackers Weekly Digest](https://ryogrid.net/pgsql-hackers-digest/) - Weekly digest of the pgsql-hackers mailing list that provides a list of active threads, thread summaries, and more.
 
 ### Podcasts
 * [PostgresFM](https://postgres.fm/) - Weekly discussions about Postgres topics.


### PR DESCRIPTION
This pull request adds a new resource to the list of newsletters section.
The update introduces the "pgsql-hackers Weekly Digest," a weekly summary of the pgsql-hackers mailing list.

New resource added:

* Added `[pgsql-hackers Weekly Digest](https://ryogrid.net/pgsql-hackers-digest/)` to the newsletters section, providing weekly summaries and active thread lists from the pgsql-hackers mailing list.

**Partial site capture**
<img width="778" height="741" alt="image" src="https://github.com/user-attachments/assets/d49255b3-9f29-44aa-8052-81d8838deb23" />
