### PR TITLE
Add TablePro to GUI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@
 * [temBoard](https://github.com/dalibo/temboard) - Web-based PostgreSQL GUI and monitoring.
 * [Teable](https://github.com/teableio/teable) - A Super fast, Real-time, Professional, Developer friendly, No code database.
 * [TablePlus](https://tableplus.com/) - Native App which let you edit database and structure. High-end security ensured (Commercial Software).
+* [TablePro](https://tablepro.app/) - Native macOS PostgreSQL client with explain visualization, ER diagrams, and AI assistant. Free, open-source.
 * [Valentina Studio](https://www.valentina-db.com/en/valentina-studio-overview) - Cross-platform database administration tool (Free/Commercial)
 * [DbGate](https://dbgate.org) - The Smartest (no)SQL Database Client
 * [WebDB](https://webdb.app) – Efficient Database IDE.


### PR DESCRIPTION
Add [TablePro](https://tablepro.app/) to the GUI section.

Native macOS PostgreSQL client with explain visualization, ER diagrams, inline editing, and AI assistant. Free and open-source.

GitHub: https://github.com/TableProApp/TablePro