### PR TITLE
Add neond to Platforms section

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@
 
 ### Platforms
 * [Atlas4D](https://github.com/crisbez/atlas4d-base) - Open-source 4D spatiotemporal platform combining PostGIS, TimescaleDB, pgvector, and H3 for unified geospatial and time-series intelligence.
+* [neond](https://github.com/matisiekpl/neond) - DX-focused control plane for Postgres with branching, PITR, and S3 durability. Ships as a single Docker container with a web dashboard; positions itself as a `postgres:latest` replacement for non-critical workloads.
 
 ### Work Queues
 * [BeanQueue](https://github.com/LaunchPlatform/bq) - A Python work queue framework based on SKIP LOCKED, LISTEN and NOTIFY


### PR DESCRIPTION
## Description

Adding neond to the Platforms section — an open-source, DX-focused control plane for Postgres with branching, PITR, and S3-backed storage.

GitHub: https://github.com/matisiekpl/neond
License: Apache 2.0
Actively maintained

## Checklist

- [x] Entry is added in alphabetical order
- [x] Format matches existing entries (name, URL, one-sentence description)
- [x] Link goes to the GitHub repo (not a commercial page)
- [x] Project is open source with a valid license
- [x] Description is concise and factual