### PR TITLE
Add pgrls (static analyzer for Postgres Row-Level Security) to Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@
 
 ### Security
 * [Acra](https://github.com/cossacklabs/acra) - SQL database security suite: proxy for data protection with transparent "on the fly" data encryption, SQL firewall (SQL injections prevention), intrusion detection system.
+* [pgrls](https://github.com/pgrls/pgrls) - static analyzer for row-level security policies; 36 rules across security, performance, and hygiene with 10 mechanically auto-fixable; includes a semantic policy-diff command for CI gating.
 
 ### Monitoring
 * [check\_pgactivity](https://github.com/OPMDG/check_pgactivity) - check\_pgactivity is designed to monitor PostgreSQL clusters from Nagios. It offers many options to measure and monitor useful performance metrics.


### PR DESCRIPTION
Adds **pgrls** — https://github.com/pgrls/pgrls — to the **Security** section.

pgrls is a static analyzer for Postgres Row-Level Security. It connects to a live database, walks the parsed AST of every policy predicate (via `pglast` / `pg_query`), and reports auth bugs, predicate logic flaws, and per-row performance traps. The current release ships **36 lint rules** (SEC001–SEC026 for security, PERF001–PERF003 for per-row performance, HYG001–HYG003 for hygiene, VIEW001–VIEW004 for view-mediated bypasses), **10 of which are mechanically auto-fixable** via `pgrls fix`. A `pgrls diff` command compares two Postgres sources (snapshot files, live databases, or migration-as-input) and classifies every change as SAFE / BREAKING / REQUIRES_REVIEW / DANGEROUS — so CI can fail merges on real security regressions without blocking safe schema migrations.

- License: MIT (OSI-approved)
- Languages: Python (≥3.11) — CLI plus a pytest plugin for RLS isolation tests
- Adoption: ~2.4k PyPI downloads / month, active development (CHANGELOG covers v0.2 → v0.5.45)
- Distribution: PyPI, pre-commit hook (`.pre-commit-hooks.yaml` in the repo), GitHub Actions / SARIF output

Entry follows the list's format: `* [name](link) - lowercase description.`, single sentence, no superlatives. Linking from the README PR description per the contributing guidelines.