### PR TITLE
Add drift to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ for `EXPLAIN`, that also provides performance tips (Commercial Software).
 * [pgroll](https://github.com/xataio/pgroll) - Zero-downtime, reversible, schema migrations for Postgres
 * [RegreSQL](https://github.com/dimitri/regresql) - Tool to build, maintain and execute a regression testing suite for SQL queries.
 * [diesel-guard](https://github.com/ayarotsky/diesel-guard) - Linter for dangerous Postgres migration patterns in Diesel and SQLx.
+* [drift](https://github.com/f4rkh4d/drift) - Multi-dialect SQL linter and formatter in Rust. Schema-aware, single binary, ships with LSP, pre-commit hook, and a GitHub Action.
 
 ### Language bindings
 * Common Lisp: [Postmodern](https://github.com/marijnh/Postmodern)


### PR DESCRIPTION
Adding [drift](https://github.com/f4rkh4d/drift) under **Utilities**, slotted next to `diesel-guard` (also a migration-safety linter).

**What it is:** multi-dialect SQL linter and formatter written in Rust. ~80 rules across 9 categories - correctness, security, schema, migration, performance, portability, conventions, ambiguity, style. Postgres is the strongest dialect (schema-aware: point it at a `pg_dump --schema-only` and it knows your tables/columns, suggests fixes for typos).

**Why it fits this list:**
- Postgres-first: dialect detection, postgres-specific rules (`drift.portability.regex-op`, `drift.portability.pg-limit-offset`, `drift.security.public-schema`, etc.).
- Code-frame diagnostics (rustc/ruff style) with caret + inline fix hint, not just rule firings.
- Schema awareness via pg_dump - `unknown-table`, `unknown-column` with suggestions.
- Single static binary, sub-second on thousands of files, ships with LSP + pre-commit hook + GitHub Action.
- MIT licensed, actively maintained.

**Live demo:** https://drift.frkhd.com/play/ (WASM build, same engine as the CLI).

The contribution guide says one PR per item; this PR adds a single line:
```
* [drift](https://github.com/f4rkh4d/drift) - Multi-dialect SQL linter and formatter in Rust. Schema-aware, single binary, ships with LSP, pre-commit hook, and a GitHub Action.
```