### PR TITLE
docs: add pgfence to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@
 ### CLI
 * [atlas](https://github.com/ariga/atlas) - Atlas is a tool for managing and migrating database schemas using modern DevOps principles.
 * [pgcli](https://github.com/dbcli/pgcli) - Postgres CLI with autocompletion and syntax highlighting
+* [pgfence](https://pgfence.com) - Lints Postgres SQL migrations for lock modes and risky DDL, with safe expand/contract rewrites. CLI plus LSP. Extractors for Prisma, TypeORM, and Knex.
 * [pgplan](https://github.com/JacobArthurs/pgplan) - compare and analyze PostgreSQL EXPLAIN plans from the CLI
 * [pgschema](https://www.pgschema.com) - Terraform-style declarative schema migration for Postgres
 * [pg-schema-diff](https://github.com/stripe/pg-schema-diff) - CLI (and Golang library) for diffing Postgres schemas and generating SQL migrations with minimal locking.


### PR DESCRIPTION
Adds pgfence to the CLI section. Static analyzer for Postgres migrations: reports lock modes, blocking DDL, and emits safe expand/contract rewrites. Apache 2.0, installable from npm. Extractors for raw SQL, Prisma, TypeORM, and Knex.

Site: https://pgfence.com