### PR TITLE
Add PromptQuery to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@
 * [sabiql](https://github.com/riii111/sabiql) - A fast, driver-less TUI to browse, query, and edit PostgreSQL databases.
 * [schemaspy](https://github.com/schemaspy/schemaspy) - SchemaSpy is a JAVA JDBC-compliant tool for generating your database to HTML documentation, including Entity Relationship diagrams
 * [pdot](https://gitlab.com/dmfay/pdot) - Visualize and explore database structures in your shell, from high-context views of the foreign key graph to trigger cascades, role inheritance and permissions, and many more
+* [PromptQuery](https://github.com/Cyberfilo/promptquery) - Deterministic, read-only natural-language-to-PostgreSQL CLI for production-scale schemas with hundreds of tables; pairs TF-IDF + LLM table-selection retrieval with a sqlglot safety guard and ships an honest, failures-included benchmark.
 * [squix](https://github.com/eduardofuncao/squix) - SQL command-line client with query management and interactive results.
 
 ### Server


### PR DESCRIPTION
Adds **PromptQuery** (`prq`) to the **CLI** section.

PromptQuery is an open-source (Apache-2.0) CLI that queries Postgres in plain English and runs the result **read-only**. It's built for real production schemas with hundreds of tables: a TF-IDF + LLM table-selector + FK-graph retrieval pipeline keeps the prompt small, a `sqlglot` guard plus a read-only session make writes impossible, and it ships an honest, *failures-included* benchmark (100% table accuracy on a 675-table Odoo 18 schema, 94% on the public EMBL-EBI RNAcentral DB) with committed receipts.

`pip install promptquery` · https://github.com/Cyberfilo/promptquery · https://pypi.org/project/promptquery/

Thanks for maintaining awesome-postgres!