### PR TITLE
Add db-retry to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ for `EXPLAIN`, that also provides performance tips (Commercial Software).
 ### Utilities
 * [apgdiff](https://www.apgdiff.com/) - Compares two database dump files and creates output with DDL statements that can be used to update old database schema to new one.
 * [bemi](https://github.com/BemiHQ/bemi) - Automatic data change tracking for PostgreSQL
+* [db-retry](https://github.com/modern-python/db-retry) - Retry helpers for transient errors in PostgreSQL and SQLAlchemy applications.
 * [ERAlchemy](https://github.com/Alexis-benoist/eralchemy) - ERAlchemy generates Entity Relation (ER) diagram from databases.
 * [flyway](https://flywaydb.org/) - Schema migration tool for Postgres and others.
 * [GatewayD](https://github.com/gatewayd-io/gatewayd) - Cloud-native database gateway and framework for building data-driven applications. Like API gateways, for databases.


### PR DESCRIPTION
Adds [db-retry](https://github.com/modern-python/db-retry) (MIT) to the Utilities section: retry helpers for transient errors in PostgreSQL and SQLAlchemy applications. Single item with a description.