### PR TITLE
Add pgvitals to Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@
 * [pg_exporter](https://github.com/Vonng/pg_exporter) - Fully customizable Prometheus exporter for PostgreSQL & Pgbouncer with fine-grained execution control.
 * [postgres_exporter](https://github.com/wrouesnel/postgres_exporter) - Prometheus exporter for PostgreSQL server metrics.
 * [StatsMgr](https://codeberg.org/data-bene/statsmgr) - An open-source PostgreSQL extension designed for efficient and organized advanced statistics management.
+* [pgvitals](https://github.com/pgvitals/pgvitals) - collection of 40 read-only diagnostic queries for spotting common performance problems (slow queries, bloat, vacuum lag, lock contention, replication lag, wraparound risk) using only the standard system catalog with no extensions required, plus an optional CLI that aggregates them into a 0-100 health score.
 
 ### Extensions
 * [pgxn](https://pgxn.org/) PostgreSQL Extension Network - central distribution point for many open-source PostgreSQL extensions.


### PR DESCRIPTION
Adds [pgvitals](https://github.com/pgvitals/pgvitals) under **Monitoring**.

pgvitals is a set of 40 read-only PostgreSQL diagnostic queries covering slow queries, index health, table bloat, vacuum/wraparound, lock contention and replication lag. They run against the standard system catalog with no extensions required, which makes them usable on locked-down or managed instances. It also ships an optional pip/Docker CLI that aggregates the suite into a 0-100 health score with an HTML report.

- Link: https://github.com/pgvitals/pgvitals
- License: MIT (open source)
- Supports PostgreSQL 13-17
- Format follows the guidelines: single link, description not capitalized, no superlatives

Disclosure: I'm the author. Happy to adjust the wording or placement if you'd prefer.