### PR TITLE
Add pgblame to Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@
 * [myDBA](https://mydba.dev) - PostgreSQL performance monitoring with 75+ automated health checks, cluster-aware index advisor, query analysis, and extension monitoring for TimescaleDB, pgvector, and PostGIS (Commercial Software).
 * [PMM](https://github.com/percona/pmm) - Percona Monitoring and Management (PMM) is a Free and Open Source platform for monitoring and managing PostgreSQL, MySQL, and MongoDB.
 * [Pome](https://github.com/rach/pome) - Pome stands for PostgreSQL Metrics. Pome is a PostgreSQL Metrics Dashboard to keep track of the health of your database.
+* [pgblame](https://pgblame.com) - Ties Postgres query regressions to the deploy that caused them: an open-source (MIT) agent snapshots pg\_stat\_statements every 60s and correlates the deltas with your Vercel/Railway/GitHub deploys. Free tier; hosted dashboard.
 * [pgmetrics](https://pgmetrics.io/) - pgmetrics is an open-source, zero-dependency, single-binary tool that can collect a lot of information and statistics from a running PostgreSQL server and display it in easy-to-read text format or export it as JSON and CSV for scripting.
 * [pg\_view](https://github.com/zalando/pg_view) - Open-source command-line tool that shows global system stats, per-partition information, memory stats and other information.
 * [pgwatch2](https://github.com/cybertec-postgresql/pgwatch2) - Flexible and easy to get started PostgreSQL metrics monitor focusing on Grafana dashboards.


### PR DESCRIPTION
Adds [pgblame](https://pgblame.com) to the **Monitoring** section.

pgblame is a deploy-correlated Postgres query monitor: a read-only agent snapshots `pg_stat_statements` every 60s and correlates query regressions with the Vercel/Railway/GitHub deploy that caused them, so a slow query points at the deploy (and commit) behind it. Works on any Postgres 13+ (Supabase, Neon, RDS, Railway, self-hosted).

The agent is open source under MIT (https://github.com/liberzon/pgblame-agent); the hosted dashboard is a freemium commercial product (free tier, no card), which I've flagged in the entry in the same style as the other commercial tools in the list.