### PR TITLE
Add pglayers to Docker images section

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ for `EXPLAIN`, that also provides performance tips (Commercial Software).
 * [citusdata/citus](https://hub.docker.com/r/citusdata/citus/) - Citus official images with citus extensions. Based on the official Postgres container.
 * [mdillon/postgis](https://hub.docker.com/r/mdillon/postgis/) - PostGIS 2.3 on Postgres 9. Based on the official Postgres container.
 * [paradedb/paradedb](https://hub.docker.com/r/paradedb/paradedb/) - ParadeDB is Postgres for Search and Analytics. Based on the official Postgres container with pg_search extension.
+* [pglayers](https://github.com/pglayers/pglayers) - Pre-built PostgreSQL extensions as composable Docker layers. 50+ extensions, ready-to-use combined images (full, Azure-compatible).
 * [postgres](https://hub.docker.com/_/postgres/) -  Official postgres container (from Docker)
 
 ### Kubernetes


### PR DESCRIPTION
Add [pglayers](https://github.com/pglayers/pglayers) to the Docker images section.

pglayers provides pre-built PostgreSQL extensions as composable Docker layers. It ships 50+ extensions and ready-to-use combined images (full, Azure-compatible) on top of the official postgres Docker images.