### PR TITLE
Add pgwd to Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@
 * [pgmetrics](https://pgmetrics.io/) - pgmetrics is an open-source, zero-dependency, single-binary tool that can collect a lot of information and statistics from a running PostgreSQL server and display it in easy-to-read text format or export it as JSON and CSV for scripting.
 * [pg\_view](https://github.com/zalando/pg_view) - Open-source command-line tool that shows global system stats, per-partition information, memory stats and other information.
 * [pgwatch2](https://github.com/cybertec-postgresql/pgwatch2) - Flexible and easy to get started PostgreSQL metrics monitor focusing on Grafana dashboards.
+* [pgwd](https://github.com/hrodrig/pgwd) - monitors PostgreSQL connection usage and stale sessions, with threshold alerts, Prometheus metrics, and multiple notification backends.
 * [pgbench](https://www.postgresql.org/docs/devel/static/pgbench.html) - Run a benchmark test on PostgreSQL.
 * [opm.io](http://opm.io) -  Open PostgreSQL Monitoring is a free software suite designed to help you manage your PostgreSQL servers. It can gather stats, display dashboards and send warnings when something goes wrong.
 * [okmeter.io](https://okmeter.io/pg) - Commercial SaaS agent-based monitoring with a very detailed PostgreSQL plugin. It automatically gathers 100s of stats, displays dashboards on every aspect and sends alerts when something goes wrong (Commercial Software).


### PR DESCRIPTION
## Summary
- Adds [pgwd](https://github.com/hrodrig/pgwd) under **Monitoring**.
- MIT-licensed Go CLI/daemon that watches PostgreSQL connection usage (total/active/idle/stale), fires threshold alerts, exposes Prometheus `/metrics`, and notifies via Slack, Loki, PagerDuty, Teams, or generic webhooks.

Disclosure: I am the maintainer of pgwd.

## Why it fits
- Actively maintained (latest release [v0.9.0](https://github.com/hrodrig/pgwd/releases/tag/v0.9.0), regular releases since Feb 2026).
- Open source (MIT), GA-quality packaging (binaries, deb/rpm, Homebrew, container image, CI).
- Public adoption signals: [gghstats traffic for hrodrig/pgwd](https://gghstats.hermesrodriguez.com/hrodrig/pgwd) (clones/views history) and GitHub release assets.

## Entry
```
* [pgwd](https://github.com/hrodrig/pgwd) - monitors PostgreSQL connection usage and stale sessions, with threshold alerts, Prometheus metrics, and multiple notification backends.
```

Thanks for considering the addition.

Made with [Cursor](https://cursor.com)