### PR TITLE
Add GeoLens to Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@
 
 ### Platforms
 * [Atlas4D](https://github.com/crisbez/atlas4d-base) - Open-source 4D spatiotemporal platform combining PostGIS, TimescaleDB, pgvector, and H3 for unified geospatial and time-series intelligence.
+* [GeoLens](https://github.com/geolens-io/geolens) - Self-hosted geospatial catalog and map builder on PostGIS, with pgvector semantic search and a job queue that runs inside Postgres.
 
 ### Work Queues
 * [BeanQueue](https://github.com/LaunchPlatform/bq) - A Python work queue framework based on SKIP LOCKED, LISTEN and NOTIFY


### PR DESCRIPTION
Adds [GeoLens](https://github.com/geolens-io/geolens) to the Platforms section, alphabetically after Atlas4D.

GeoLens is a self-hosted geospatial catalog and map builder that leans on Postgres for nearly everything: PostGIS for storage and vector tiles, pgvector and pg_trgm for search. The ingest job queue (Procrastinate) also runs inside Postgres, so there is no separate broker to operate.

Live demo: https://demo.getgeolens.com
License: Apache-2.0, current release v1.4.9

Disclosure: I'm the author. The project went public in June 2026 and runs in production (the demo above plus self-hosted installs). If you'd rather see more mileage before listing it, that's fair, happy to come back later.