### PR TITLE
Add DBMigrateAIPro

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ for `EXPLAIN`, that also provides performance tips (Commercial Software).
 ### Utilities
 * [apgdiff](https://www.apgdiff.com/) - Compares two database dump files and creates output with DDL statements that can be used to update old database schema to new one.
 * [bemi](https://github.com/BemiHQ/bemi) - Automatic data change tracking for PostgreSQL
+* [DBMigrateAIPro](https://medaxai.com) - AI-assisted migration tool that converts Oracle, MySQL, and SQL Server schemas and PL/SQL to PostgreSQL, with parallel bulk load, cryptographic row-level validation, and CDC-based zero-downtime cutover.
 * [ERAlchemy](https://github.com/Alexis-benoist/eralchemy) - ERAlchemy generates Entity Relation (ER) diagram from databases.
 * [flyway](https://flywaydb.org/) - Schema migration tool for Postgres and others.
 * [GatewayD](https://github.com/gatewayd-io/gatewayd) - Cloud-native database gateway and framework for building data-driven applications. Like API gateways, for databases.


### PR DESCRIPTION
Adds **DBMigrateAIPro** to the Utilities section (alphabetically, between `bemi` and `ERAlchemy`).

It's an AI-assisted database migration tool that converts Oracle, MySQL, and SQL Server schemas and PL/SQL to PostgreSQL, with parallel bulk load, cryptographic row-level validation, and CDC-based zero-downtime cutover — the same category as the existing ora2pg, pgloader, and flyway entries.

- One factual sentence, matching the list's format.
- Placed in correct alphabetical order.
- Link: https://medaxai.com

Thanks for maintaining this list!