### PR TITLE
Add @imqueue/pg-pubsub to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ for `EXPLAIN`, that also provides performance tips (Commercial Software).
 * [PostGraphile](https://github.com/graphile/postgraphile) - Instant GraphQL API or GraphQL schema for your PostgreSQL database
 * [yoke](https://github.com/nanopack/yoke) - PostgreSQL high-availability cluster with auto-failover and automated cluster recovery.
 * [pglistend](https://github.com/kabirbaidhya/pglistend) - A lightweight PostgresSQL `LISTEN`/`NOTIFY` daemon built on top of `node-postgres`.
+* [@imqueue/pg-pubsub](https://github.com/imqueue/pg-pubsub) - Reliable PostgreSQL `LISTEN`/`NOTIFY` with inter-process lock support, for Node.js and TypeScript.
 * [ZSON](https://github.com/postgrespro/zson) - PostgreSQL extension for transparent JSONB compression
 * [pg_bulkload](http://ossc-db.github.io/pg_bulkload/index.html) - It's a high speed data loading utility for PostgreSQL.
 * [pg_migrate](https://github.com/jwdeitch/pg_migrate) - Manage PostgreSQL codebases and make VCS simple.


### PR DESCRIPTION
Adds [@imqueue/pg-pubsub](https://github.com/imqueue/pg-pubsub) to the Utilities section, next to `pglistend`.

It's a reliable PostgreSQL `LISTEN`/`NOTIFY` library for Node.js/TypeScript that adds inter-process locking (so a single consumer handles a notification across a cluster). Open source (GPL-3.0), on npm, tested and actively maintained (v3.0.0, 115★).

- One item, added to the bottom of the relevant category.
- Links to the GitHub repository.
- Format: `[item](link) - description.`