### PR TITLE
Add SchemaSmith to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ for `EXPLAIN`, that also provides performance tips (Commercial Software).
 * [pg_migrate](https://github.com/jwdeitch/pg_migrate) - Manage PostgreSQL codebases and make VCS simple.
 * [pg_timetable](https://github.com/cybertec-postgresql/pg_timetable) - Advanced job scheduler for PostgreSQL.
 * [sqitch](https://github.com/sqitchers/sqitch) - Tool for managing versioned schema deployment
+* [SchemaSmith](https://github.com/Schema-Smith/SchemaSmith) - state-based schema management for PostgreSQL and other databases; declare the desired state instead of writing migration scripts. (Source-available)
 * [pgmigrate](https://github.com/yandex/pgmigrate) - CLI tool to evolve schema migrations, developed by Yandex.
 * [pgcmp](https://github.com/cbbrowne/pgcmp) - Tool to compare database schemas, with capability to accept some persistent differences
 * [pg-differ](https://github.com/multum/pg-differ) - Tool for easy initialization / updating of the structure of PostgreSQL tables, migration alternative (Node.js).


### PR DESCRIPTION
Adds [SchemaSmith](https://github.com/Schema-Smith/SchemaSmith) under **Utilities**, near sqitch.

SchemaSmith is a free, source-available (SSCL v2.0) state-based schema management toolset for PostgreSQL (and SQL Server, MySQL, MariaDB) — declare the desired database state as metadata and it transforms any target to match, with no ordered migration scripts to author. Cross-platform (Windows/Linux/macOS), GA-quality with CI-tested releases (v2.3.0).

Per the contribution guidelines it needs a note when a tool isn't fully open source; I used `(Source-available)` since the tools are free but under a non-OSI source-available license (SSCL v2.0). Happy to switch to `(Commercial Software)` if you prefer the exact wording from the guidelines.