### PR TITLE
Add QuelPad to GUI clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@
 * [Postbird](https://github.com/Paxa/postbird) - PostgreSQL Client for macOS.
 * [PostgresCompare](https://www.postgrescompare.com) - Cross-platform database comparison and deployment tool (Commercial Software).
 * [Postico](https://eggerapps.at/postico/) - Modern PostgreSQL Client for macOS (Commercial Software).
+* [QuelPad](https://quelpad.com) - TypeScript scratchpad and database client with strong PostgreSQL support (incl. Neon); query, transform and chart with typed scripts, or ask in plain English. Cross-platform for macOS and Windows (Freemium).
 * [QueryGlow](https://queryglow.com/) - Self-hosted, web-based database GUI with AI SQL generation, EXPLAIN visualizer, and schema-aware autocomplete (Commercial Software).
 * [PSequel](http://www.psequel.com/) - Clean and simple interface to perform common PostgreSQL tasks quickly (Commercial Software).
 * [Redash](https://github.com/getredash/redash) - Connect to any data source, easily visualize and share your data.


### PR DESCRIPTION
Adds [QuelPad](https://quelpad.com) to the **GUI** section.

QuelPad is a TypeScript-first scratchpad + database client with strong PostgreSQL support, including serverless Postgres (Neon). You connect and then query, transform and chart your data with typed TypeScript scripts — or ask in plain English. Cross-platform (macOS, Windows), freemium. Placed alphabetically between Postico and QueryGlow.