### PR TITLE
Add Nhost to PaaS (PostgreSQL as a Service)

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ for `EXPLAIN`, that also provides performance tips (Commercial Software).
 * [PlanetScale](https://planetscale.com/postgres) - PlanetScale for Postgres provides fully-managed, high availability PostgreSQL database clusters built on modern cloud infrastructure.
 * [Vela](https://vela.run) - Postgres-based backend-as-a-service built for modern AI apps. Offers instant database branches and clones, production-like test environments, and serverless scaling.
 * [Thalassa Cloud DBaaS](https://thalassa.cloud/products/databases/postgresql/) - Fully managed PostgreSQL database, multi-AZ, automated backups, hosted in the Netherlands.
+* [Nhost](https://nhost.io) - Open source Postgres backend platform with an instant Hasura GraphQL API, authentication, storage, and serverless functions, built for web and AI/agentic apps.
 
 ### Docker images
 * [citusdata/citus](https://hub.docker.com/r/citusdata/citus/) - Citus official images with citus extensions. Based on the official Postgres container.


### PR DESCRIPTION
Adds [Nhost](https://nhost.io) to the PaaS (PostgreSQL as a Service) section, alongside Supabase, Neon and Vela.

Nhost is an open source (MIT) Postgres backend platform: PostgreSQL database, instant Hasura GraphQL API, authentication, file storage, and serverless functions. It is a widely adopted, GA, actively maintained Firebase/Supabase alternative.

Project: https://nhost.io
Source code: https://github.com/nhost/nhost

One item, one link, English, per the contribution guidelines.