### PR TITLE
Add Layerbase to PaaS (PostgreSQL as a Service)

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ for `EXPLAIN`, that also provides performance tips (Commercial Software).
 * [PlanetScale](https://planetscale.com/postgres) - PlanetScale for Postgres provides fully-managed, high availability PostgreSQL database clusters built on modern cloud infrastructure.
 * [Vela](https://vela.run) - Postgres-based backend-as-a-service built for modern AI apps. Offers instant database branches and clones, production-like test environments, and serverless scaling.
 * [Thalassa Cloud DBaaS](https://thalassa.cloud/products/databases/postgresql/) - Fully managed PostgreSQL database, multi-AZ, automated backups, hosted in the Netherlands.
+* [Layerbase](https://layerbase.com) - Fully managed PostgreSQL alongside 17 other database engines under one account and dashboard. Copy-on-write branching, automated backups, and scale-to-zero with wake on connect.
 
 ### Docker images
 * [citusdata/citus](https://hub.docker.com/r/citusdata/citus/) - Citus official images with citus extensions. Based on the official Postgres container.


### PR DESCRIPTION
Adds Layerbase to the PaaS *(PostgreSQL as a Service)* section.

Link: https://layerbase.com

**Disclosure:** I am the founder of Layerbase, so this is a self-submission.

Layerbase is a commercial managed database service. It runs fully managed PostgreSQL alongside 17 other engines under one account and dashboard, with copy-on-write branching, automated backups, and scale-to-zero that wakes on connect. It is generally available and running production workloads.

Appended at the end of the section to match how the recent entries (Vela, Thalassa Cloud DBaaS) were added, and formatted as `* [item](link) - description.` per CONTRIBUTING. Single link, no documentation links. Happy to add a `(Commercial Software)` note if you want it, though no existing entry in this section carries one.