### PR TITLE
Add LibreDB Studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@
 * [DbVisualizer](http://www.dbvis.com) - Cross-platform database client for developers, DBAs, and analysts (Commercial Software).
 * [Holistics](https://www.holistics.io/) - Online cross platform database management tool and SQL query reporting GUI with strong PostgreSQL support (Commercial Software).
 * [JackDB](https://www.jackdb.com/) - Web-based SQL query interface (Commercial Software).
+* [LibreDB Studio](https://github.com/libredb/libredb-studio) - Browser-based SQL IDE that deploys next to the database as a container or Helm chart, with schema explorer, ER diagrams, schema diff and live monitoring.
 * [Luna Modeler](http://www.datensen.com) - Cross-platform desktop data modeling tool (Commercial Software).
 * [Mathesar](https://mathesar.org/) -  Web application providing an intuitive user experience to databases.
 * [Metabase](https://www.metabase.com/) - Simple dashboards, charts and query tool for PostgreSQL.


### PR DESCRIPTION
Adds LibreDB Studio to the GUI section, in alphabetical order.

- Repo: https://github.com/libredb/libredb-studio
- License: MIT, so no `(Commercial Software)` note
- Install: `docker run -d -p 3000:3000 ghcr.io/libredb/libredb-studio:latest`

It is a browser-based SQL IDE meant to run inside the same network as the database rather than on a laptop, so there is no port to expose and no tunnel to dig. Postgres support covers the schema explorer, auto-generated ER diagrams, schema diff with migration SQL, EXPLAIN plans, and a monitoring view backed by `pg_stat_activity`. It also ships as a Helm chart and an OLM operator, and as an npm package for embedding.
