### PR TITLE
Add pgmnemo (agent-memory extension)

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@
 * [pg_cron](https://github.com/citusdata/pg_cron) - Run periodic jobs in PostgreSQL.
 * [pglogical](https://github.com/2ndQuadrant/pglogical) - Extension that provides logical streaming replication.
 * [pgcat](https://github.com/kingluo/pgcat) - Enhanced PostgreSQL logical replication
+* [pgmnemo](https://github.com/pgmnemo/pgmnemo) - Memory for AI coding agents as an extension: hybrid HNSW+BM25 recall, write-time provenance gates, and an outcome loop measured against a no-memory control (dataset published in-repo).
 * [pg\_barcode](https://github.com/btouchard/pg_barcode/) - PostgreSQL SVG QRcode & Datamatrix generator.
 * [pg\_partman](https://github.com/pgpartman/pg_partman) - Partition management extension for PostgreSQL.
 * [pg\_paxos](https://github.com/citusdata/pg_paxos/) - Basic implementation of Paxos and Paxos-based table replication for a cluster of PostgreSQL nodes.


### PR DESCRIPTION
Adds [pgmnemo](https://github.com/pgmnemo/pgmnemo) to Extensions, next to the pg* cluster.

Memory for AI coding agents as a PostgreSQL extension: hybrid HNSW+BM25 recall in one query plan, a write-time provenance gate at the constraint layer, and an outcome-weighted confidence loop. Distinctive enough to mention: the repo publishes a randomized on/off/selective experiment from a live agent fleet — dataset, analysis script, and the negative result included. Apache-2.0, on PGXN and PyPI.