### PR TITLE
Add DBTool to GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@
 * [DBConvert Streams](https://streams.dbconvert.com/) - A cloud-native platform for real-time data migration and CDC replication between PostgreSQL and MySQL databases across various cloud environments. (Commercial Software).
 * [DBeaver](https://dbeaver.io/) - Universal Database Manager with excellent support for PostgreSQL.
 * [dbForge Edge](https://www.devart.com/dbforge/edge/) - All-in-one multidatabase solution supporting PostgreSQL, MySQL, MariaDB, SQL Server, Oracle, and a wide range of related cloud services (Commercial Software). 
+* [DBTool](https://github.com/achi777/db-tool) - Free and open-source cross-platform desktop client with full PostgreSQL support, including materialized views, enums and composite types, extensions, and btree/hash/gin/gist/brin plus partial and expression indexes.
 * [DbVisualizer](http://www.dbvis.com) - Cross-platform database client for developers, DBAs, and analysts (Commercial Software).
 * [Holistics](https://www.holistics.io/) - Online cross platform database management tool and SQL query reporting GUI with strong PostgreSQL support (Commercial Software).
 * [JackDB](https://www.jackdb.com/) - Web-based SQL query interface (Commercial Software).


### PR DESCRIPTION
Adds **DBTool** to the GUI section, in the list's existing order.

[DBTool](https://github.com/achi777/db-tool) is a free, open-source (AGPL-3.0) desktop database client with native builds for Windows, macOS and Linux. On the PostgreSQL side it covers materialized views, user-defined types and enums, extensions and sequences as first-class objects in the tree, and index types beyond btree (hash, gin, gist, brin, plus partial and expression indexes) in the visual designer.

It has true server-side pagination (ordering, counting and paging happen in the database rather than in the client), a schema-aware SQL editor, a drag-to-join visual query builder that generates the `SELECT`, a visual table designer with a live DDL preview, and editable ER diagrams. Connection passwords are stored in the OS keychain; there is no telemetry and no account.

I am the author of this project.
