### PR TITLE
Add Sutido to GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@
 * [Redash](https://github.com/getredash/redash) - Connect to any data source, easily visualize and share your data.
 * [SQL Tabs](http://www.sqltabs.com/) - Cross Platform Desktop Client for PostgreSQL written in JS.
 * [SQLPro for Postgres](http://macpostgresclient.com/) - Simple, powerful PostgreSQL manager for macOS (Commercial Software).
+* [Sutido](https://sutido.com) - Windows desktop client covering PostgreSQL, MongoDB, SQL Server, Aerospike and ClickHouse in one window, with autocomplete from the live schema, SSH tunneling and server-side query cancellation (Commercial Software).
 * [temBoard](https://github.com/dalibo/temboard) - Web-based PostgreSQL GUI and monitoring.
 * [Teable](https://github.com/teableio/teable) - A Super fast, Real-time, Professional, Developer friendly, No code database.
 * [TablePlus](https://tableplus.com/) - Native App which let you edit database and structure. High-end security ensured (Commercial Software).


### PR DESCRIPTION
Adds [Sutido](https://sutido.com) to `Tools > GUI`, alphabetically between SQLPro for Postgres and temBoard.

Sutido is a Windows desktop client that connects to PostgreSQL, MongoDB, SQL Server, Aerospike and ClickHouse from a single workspace. On the PostgreSQL side:

- Autocomplete from the live schema - tables, columns, functions and keywords - in a Monaco-based editor.
- Scripts are split into statements and run on one pinned pool connection, so session state (`SET`, temp tables, transactions) behaves the way it does in `psql`.
- Abort actually cancels server-side via `pg_cancel_backend`, rather than only abandoning the result.
- Destructive statements are scanned before anything is sent and raise a confirmation naming the table - including the case where a partial editor selection turns `DELETE FROM t WHERE ...` into an unqualified `DELETE FROM t`.
- SSH tunnelling with trust-on-first-use host keys, for databases behind a bastion.
- Secrets (passwords, SSH keys) are stored with OS-level encryption, never plaintext.

On the general conditions: it is closed source, so the entry carries the required `(Commercial Software)` note. It is a shipping product at 0.11 in daily production use rather than an untested script, though I will note plainly that it is young - entirely your call whether that clears the "reasonably recognized and adopted" bar, and no hard feelings if it does not yet.

Link: https://sutido.com