### PR TITLE
Add Syncle to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ for `EXPLAIN`, that also provides performance tips (Commercial Software).
 * [pgroll](https://github.com/xataio/pgroll) - Zero-downtime, reversible, schema migrations for Postgres
 * [RegreSQL](https://github.com/dimitri/regresql) - Tool to build, maintain and execute a regression testing suite for SQL queries.
 * [diesel-guard](https://github.com/ayarotsky/diesel-guard) - Linter for dangerous Postgres migration patterns in Diesel and SQLx.
+* [Syncle](https://syncle.dev) - Web interface for syncing rows between Postgres and MySQL, SQLite, MongoDB or Redis, by backfill, polling, or logical replication.
 
 ### Language bindings
 * Common Lisp: [Postmodern](https://github.com/marijnh/Postmodern)


### PR DESCRIPTION
Adds [Syncle](https://syncle.dev) to **Utilities**, beside tools like pgloader and pgsync.

It syncs rows between Postgres and MySQL/MariaDB, SQLite, MongoDB or Redis, in either direction. For a Postgres source it reads the change log directly through logical replication — creating and managing the publication and slot itself — and can also run a one-off backfill or poll a cursor instead. Writes are idempotent upserts keyed by the columns you choose, missing destination tables are created with type translation across engines, and interrupted jobs resume from their cursor.

Self-hosted and MIT licensed: four containers behind one published port, installed with one command. Docs at https://syncle.dev/docs, source at https://github.com/osmanahmadxai/SYNCLE.

**On the maturity guideline** — I would rather be straight with you than have you find out in the diff. Syncle's first stable release was 23 July 2026, so it is young, and it has not yet been adopted widely enough to call "reasonably recognized". It is GA quality and functioning rather than an untested script: tagged releases, documentation for every command and endpoint, a test suite, and a published Docker image. If that is short of the bar for this list, no hard feelings at all — close it and I will resubmit when there is real adoption to point at.
