### PR TITLE
Add Picodata to Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@
 * [AgensGraph](https://bitnine.net/) - Powerful graph database based on the PostgreSQL.
 * [Apache Cloudberry](https://github.com/apache/cloudberry) - And MPP PostgreSQL fork. Open source alternative to Greenplum Database.
 * [FerretDB](https://www.ferretdb.io) - A truly Open Source MongoDB alternative on top of PostgreSQL.
+* [Picodata](https://picodata.io/en/) - Distributed PostgreSQL-compatible database in Rust; Redis and Cassandra wire compatibility via commercial plugins.
 * [Postgres-XL](https://www.postgres-xl.org/) - Scalable Open Source PostgreSQL-based Database Cluster.
 * [YugabyteDB](https://yugabyte.com/) - Open Source Distributed SQL using  a fork of PostgreSQL on top of distributed storage and transaction
 


### PR DESCRIPTION
Adding [Picodata](https://picodata.io/en/) to the Server section.

**Disclosure:** I work on Picodata, so this is a self-submission.

- **Licence:** the core is BSD-2-Clause — source at https://git.picodata.io/core/picodata. The Redis and Cassandra compatibility plugins are commercial, which the description states explicitly so the entry is not claiming more open source than it has.
- **Maturity:** GA, in production at banks and telecom operators; not a new or untested project.