### PR TITLE
Add mcdview to GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@
 * [JackDB](https://www.jackdb.com/) - Web-based SQL query interface (Commercial Software).
 * [Luna Modeler](http://www.datensen.com) - Cross-platform desktop data modeling tool (Commercial Software).
 * [Mathesar](https://mathesar.org/) -  Web application providing an intuitive user experience to databases.
+* [mcdview](https://mcdview.dev) - Generates a single self-contained interactive ER diagram page from a SQL schema, dump, or pgModeler .dbm. No account and no database connection; the CLI generator is open source (MIT).
 * [Metabase](https://www.metabase.com/) - Simple dashboards, charts and query tool for PostgreSQL.
 * [Numeracy](https://numeracy.co/) - Fast SQL editor with charts and dashboards for PostgreSQL (Commercial Software).
 * [OrcaQ](https://github.com/cin12211/orca-q) - A modern, open-source database editor for PostgreSQL, MySQL, Redis, and more. Features an AI assistant, ERD visualizer, schema diff, and visual role management.


### PR DESCRIPTION
Adds **mcdview** to the GUI section (alongside pgModeler, SchemaSpy and the other modeling/ERD tools).

[mcdview](https://mcdview.dev) generates a single self-contained interactive ER diagram page from a SQL schema, a dump, or a pgModeler `.dbm` model. It reads only the structure (no live database connection), requires no account, and the CLI generator is open source under MIT (https://github.com/Gheop/mcdview). Entry inserted alphabetically.