### PR TITLE
Add cli2ui to GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@
 * [Beekeeper Studio](https://www.beekeeperstudio.io) - Free and open source SQL client with a modern UI and great Postgres support. Cross platform.
 * [Bytebase](https://www.bytebase.com) - Database DevSecOps solution for Developer, Security, DBA, and Platform Engineering teams.
 * [Chartbrew](https://chartbrew.com) - Create live dashboards, charts, and client reports from PostgreSQL data. Features a query tool that works with SQL.
+* [cli2ui](https://github.com/MR-TABATA/cli2ui) - Local-only web UI over the psql commands you keep half-remembering: health checks, blocking trees, replication lag, and — before you press a destructive button — the exact SQL it will run and what a TRUNCATE or DROP takes with it.
 * [Count](https://count.co/) - Web-based analytics platform with a notebook interface which connects to PostgreSQL (Commercial Software).
 * [DataGrip](https://www.jetbrains.com/datagrip/) - IDE with advanced tool sets and good cross-platform experience (Commercial Software).
 * [Dekart](https://github.com/dekart-xyz/dekart) - Open-source platform to turn PostGIS queries into shareable interactive maps.


### PR DESCRIPTION
Adds **cli2ui** to GUI, alphabetically between `Chartbrew` and `Count`.

cli2ui is a local-only web UI over the `psql` operations you keep half-remembering — `pg_stat_activity`, `pg_locks`, `pg_stat_replication`, `pg_dump` — turned into buttons. It runs on your machine, has no authentication by design, and is meant for app developers rather than DBAs.

What is different from the clients already in this section: **it says what a destructive button is about to do, before you press it.**

- the exact SQL the button will send, composed by the same code path that executes it — not a second rendering that can drift from it
- what a `TRUNCATE` or `DROP … CASCADE` takes with it: dependent views and materialized views by name, and foreign keys pointing at the table
- estimated row counts from planner statistics, labelled as estimates — a table that has never been analyzed reports **unknown**, not zero
- the `SET lock_timeout` that guards every destructive DDL, shown rather than merely applied

It also does the read-only side: health checks (unindexed foreign keys, redundant and invalid indexes, orphan rows, NULL gaps in composite UNIQUE constraints), head-blocker trees for `pg_locks`, standby replay lag in time rather than bytes, an `EXPLAIN` plan differ, and a what-if index lab that builds an index inside a transaction that is always rolled back.

MIT, `docker compose up`, and a sample database is bundled and pre-wired into the connection form, so there is nothing to install and no demo database to go find.

I am the author.

- [x] Alphabetical position within the section
- [x] Not already listed
- [x] Link resolves
