### PR TITLE
Add sql2erd to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ for `EXPLAIN`, that also provides performance tips (Commercial Software).
 * [pg_migrate](https://github.com/jwdeitch/pg_migrate) - Manage PostgreSQL codebases and make VCS simple.
 * [pg_timetable](https://github.com/cybertec-postgresql/pg_timetable) - Advanced job scheduler for PostgreSQL.
 * [sqitch](https://github.com/sqitchers/sqitch) - Tool for managing versioned schema deployment
+* [sql2erd](https://sql2erd.dev) - In-browser SQL DDL to ERD diagram generator running client-side via WebAssembly.
 * [pgmigrate](https://github.com/yandex/pgmigrate) - CLI tool to evolve schema migrations, developed by Yandex.
 * [pgcmp](https://github.com/cbbrowne/pgcmp) - Tool to compare database schemas, with capability to accept some persistent differences
 * [pg-differ](https://github.com/multum/pg-differ) - Tool for easy initialization / updating of the structure of PostgreSQL tables, migration alternative (Node.js).


### PR DESCRIPTION
### Description
Add [sql2erd](https://sql2erd.dev) to the Utilities section.

### Details
- **Tool:** [sql2erd](https://sql2erd.dev)
- **Description:** In-browser SQL DDL to ERD diagram generator running client-side via WebAssembly.
- **Category:** Utilities (ordered alphabetically between `sqitch` and `sqlcheck`).
- **Access & Privacy:** 100% free web tool, no sign-up or credentials required. All schema parsing and diagram layout are performed client-side via WebAssembly; schema data never leaves the browser.